### PR TITLE
chore: dev setup for custom editors/IDEs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,8 +5,12 @@
   "tasks": [
     {
       "taskName": "Watch and compile TypeScript",
-      "command": "tsc",
-      "args": ["--watch"],
+      "command": "npm",
+      "args": [
+        "--silent",
+        "run",
+        "build:watch"
+      ],
       "type": "process",
       "isBackground": true,
       "problemMatcher": "$tsc-watch",
@@ -27,7 +31,7 @@
       "args": [
         "--silent",
         "run",
-        "vscode-test"
+        "test:dev"
       ],
       "type": "process",
       "group": {

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,9 +13,19 @@ Install the following extensions:
 
 ## Development workflow
 
+### Visual Studio Code
+
 1. Start the build task (Cmd+Shift+B), it will run TypeScript compiler in backround, watching and recompiling files as you change them. Compilation errors will be shown in the VSCode's "PROBLEMS" window.
 
 
 2. Execute "Test and lint" task (Cmd+Shift+T) to re-run the test suite and lint the code for both programming and style errors. Linting errors will be shown in VSCode's "PROBLEMS" window. Failed tests are printed to terminal output only.
 
-3. Run "npm test" explicitly before committing your changes. This will execute the same sequence as our CI server does.
+3. Run `npm test` explicitly before committing your changes. This will execute the same sequence as our CI server does.
+
+### Other editors/IDEs
+
+1. Open a new terminal window/tab and start the continuos build process via `npm run build:watch`. It will run TypeScript compiler in watch mode, recompiling files as you change them. Any compilation errors will be printed to this terminal.
+
+2. In your main terminal window/tab, run `npm run test:dev` to re-run the test suite and lint the code for both programming and style errors. You should run this command manually whenever you have new changes to test. Test failures and linter errors will be printed to this terminal.
+
+3. Run `npm test` explicitly before committing your changes. This will execute the same sequence as our CI server does.

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
     "build": "npm run build:lib && npm run build:lib6",
     "build:lib": "tsc --target es2017 --outDir dist",
     "build:lib6": "tsc --target es2015 --outDir dist6",
+    "build:watch": "tsc --watch",
     "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
     "lint:fix": "npm run lint -- --fix",
     "prepublish": "npm run build",
     "pretest": "npm run build",
     "test": "mocha",
     "posttest": "npm run lint",
-    "vscode-test": "mocha && npm run lint"
+    "test:dev": "mocha && npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
 - Rename "vscode-test" task to "test:dev".

 - Add a new task "build:watch" for running tsc in watch mode.

 - Update DEVELOPING.md with instructions for people not using VS Code.

See https://github.com/strongloop/loopback-next-extension-starter/pull/7#discussion_r142101647 and #2.