### PR TITLE
build: use prettier to format the code

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+dist
+dist6
+api-docs
+*.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,4 @@
 {
-  "eslintIntegration": true,
   "bracketSpacing": false,
   "singleQuote": true,
   "printWidth": 80,

--- a/package.json
+++ b/package.json
@@ -12,8 +12,13 @@
     "build:lib6": "tsc --target es2015 --outDir dist6",
     "build:watch": "tsc --watch",
     "clean": "rm -rf dist dist6",
-    "lint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
-    "lint:fix": "npm run lint -- --fix",
+    "lint": "npm run prettier:check && npm run tslint",
+    "lint:fix": "npm run prettier:fix && npm run tslint:fix",
+    "prettier:cli": "prettier \"**/*.ts\" \"**/*.js\"",
+    "prettier:check": "npm run prettier:cli -- -l",
+    "prettier:fix": "npm run prettier:cli -- --write",
+    "tslint": "tslint -c tslint.full.json --project tsconfig.json --type-check",
+    "tslint:fix": "npm run lint -- --fix",
     "prepublish": "npm run build",
     "pretest": "npm run clean && npm run build",
     "test": "mocha",
@@ -22,18 +27,21 @@
   },
   "repository": {
     "type": "git",
-    "url":
-      "git+https://github.com/strongloop/loopback-next-extension-starter.git"
+    "url": "git+https://github.com/strongloop/loopback-next-extension-starter.git"
   },
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url":
-      "https://github.com/strongloop/loopback-next-extension-starter/issues"
+    "url": "https://github.com/strongloop/loopback-next-extension-starter/issues"
   },
-  "homepage":
-    "https://github.com/strongloop/loopback-next-extension-starter#readme",
-  "files": ["README.md", "index.js", "index.d.ts", "dist", "dist6"],
+  "homepage": "https://github.com/strongloop/loopback-next-extension-starter#readme",
+  "files": [
+    "README.md",
+    "index.js",
+    "index.d.ts",
+    "dist",
+    "dist6"
+  ],
   "dependencies": {
     "@loopback/context": "^4.0.0-alpha.14",
     "@loopback/core": "^4.0.0-alpha.16",
@@ -44,6 +52,7 @@
     "@loopback/testlab": "^4.0.0-alpha.9",
     "@types/mocha": "^2.2.43",
     "mocha": "^3.5.3",
+    "prettier": "^1.7.4",
     "tslint": "^5.7.0",
     "typescript": "^2.5.2"
   }

--- a/tslint.full.json
+++ b/tslint.full.json
@@ -1,21 +1,17 @@
 {
-    "$schema": "http://json.schemastore.org/tslint",
-    "extends": [
-      "./tslint.json"
-    ],
-    // This configuration files enabled rules which require type checking
-    // and therefore cannot be run by Visual Studio Code TSLint extension
-    // See https://github.com/Microsoft/vscode-tslint/issues/70
-    "rules": {
-      // These rules find errors related to TypeScript features.
-  
-  
-      // These rules catch common errors in JS programming or otherwise
-      // confusing constructs that are prone to producing bugs.
-  
-      "await-promise": true,
-      "no-floating-promises": true,
-      "no-void-expression": [true, "ignore-arrow-function-shorthand"]
-    }
+  "$schema": "http://json.schemastore.org/tslint",
+  "extends": ["./tslint.json"],
+  // This configuration files enabled rules which require type checking
+  // and therefore cannot be run by Visual Studio Code TSLint extension
+  // See https://github.com/Microsoft/vscode-tslint/issues/70
+  "rules": {
+    // These rules find errors related to TypeScript features.
+
+    // These rules catch common errors in JS programming or otherwise
+    // confusing constructs that are prone to producing bugs.
+
+    "await-promise": true,
+    "no-floating-promises": true,
+    "no-void-expression": [true, "ignore-arrow-function-shorthand"]
   }
-  
+}

--- a/tslint.json
+++ b/tslint.json
@@ -21,52 +21,11 @@
     "no-string-throw": true,
     "no-unused-expression": true,
     "no-var-keyword": true,
-    "triple-equals": [
-      true,
-      "allow-null-check",
-      "allow-undefined-check"
-    ],
+    "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
     "typeof-compare": true,
 
     // These rules make code maintenance easier
-    "eofline": true,
-    "indent": [true, "spaces"],
     "no-default-export": true,
-    "no-trailing-whitespace": true,
-    "prefer-const": true,
-    "trailing-comma": [true, {
-      "multiline": "always",
-      "singleline": "never"
-    }],
-
-    // These rules enforce consistent style across your codebase:
-    "arrow-return-shorthand": [true],
-    "class-name": true,
-    "comment-format": [true, "check-space"],
-    "file-header": [true, "Copyright IBM"],
-    "max-line-length": [true, 80],
-    "no-consecutive-blank-lines": [true, 2],
-    "no-unnecessary-callback-wrapper": true,
-    "one-variable-per-declaration": [true, "ignore-for-loop"],
-    "prefer-method-signature": true,
-    "quotemark": [true, "single", "avoid-escape"],
-    "semicolon": [true, "always"],
-    "space-before-function-paren": [true, {
-      "anonymous": "never",
-      "named": "never",
-      "asyncArrow": "always",
-      "method": "never",
-      "constructor": "never"
-    }],
-    "variable-name": [true, "allow-leading-underscore", "ban-keywords", "check-format"],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-separator",
-      "check-type",
-      "check-typecast",
-      "check-preblock"
-    ]
+    "prefer-const": true
   }
 }


### PR DESCRIPTION
Add a build step to `npm run test` to verify that all code has been formatted by prettier.

Developers can run `npm run lint:fix` to get the formatting fixed for them.

This is a follow-up for https://github.com/strongloop/loopback-next/pull/601.